### PR TITLE
chore(make): add clean target for screenshot debug artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: clean
+clean:
+	rm -f screenshots/*.png
+
 .PHONY: create-github-release
 create-github-release:
 	@VERSION=$(shell jq -r .version package.json) && \


### PR DESCRIPTION
Add a `make clean` target that removes PNG files under screenshots/
produced by `main.ts --screenshot-dir` during local debugging.

Co-authored-by: Cursor <cursoragent@cursor.com>
