### PR TITLE
refactor(main): write feedlyToken only with -o

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # feedly-token-fetcher
 
-CLI tool that opens Feedly with Playwright, refreshes the Playwright storage state, and prints `feedlyToken`.
+CLI tool that opens Feedly with Playwright and refreshes the Playwright storage state. Optionally writes `feedlyToken` to a file with `-o`.
 
 ## Setup: `state.json`
 
@@ -42,15 +42,15 @@ npx playwright install chromium
 npx tsx main.ts state.json
 ```
 
-If the session is valid, the tool navigates to the reader (`/i/`), updates `state.json`, and prints `feedlyToken` to stdout.
+If the session is valid, the tool navigates to the reader (`/i/`) and updates `state.json`.
 
 ## Usage
 
 ```bash
-# Print token to stdout and update state.json
+# Update state.json
 npx tsx main.ts state.json
 
-# Write token to a file
+# Also write feedlyToken to a file
 npx tsx main.ts state.json -o token.txt
 
 # Debug (verbose logs and success/error screenshots)
@@ -61,7 +61,7 @@ npm run dev
 
 | Option | Description |
 |--------|-------------|
-| `-o, --output <file>` | Write token to this file (default: stdout) |
+| `-o, --output <file>` | Write `feedlyToken` to this file |
 | `-v, --verbose` | Enable debug logging |
 | `-s, --screenshot-dir <dir>` | Save screenshots on success and on error |
 

--- a/main.ts
+++ b/main.ts
@@ -14,7 +14,7 @@ program
     '[storageState]',
     'storage state JSON containing Feedly auth information',
   )
-  .option('-o, --output <file>', 'Output file name (default: standard output)')
+  .option('-o, --output <file>', 'Write feedlyToken to this file')
   .option('-v, --verbose', 'Enable verbose logging (debug level)', false)
   .option(
     '-s, --screenshot-dir <dir>',
@@ -131,19 +131,12 @@ const fetchNewStorageState = async (storageStateJson: string) => {
   }
 };
 
-const outputFeedlyToken = async (
-  fileName: string | undefined,
-  token: string,
-) => {
-  if (fileName) {
-    try {
-      await writeFile(fileName, token, 'utf-8');
-      logger.info(`Wrote Feedly token to ${fileName}`);
-    } catch (error) {
-      logger.error(`Error writing to file: ${error}`);
-    }
-  } else {
-    console.log(token);
+const writeFeedlyTokenToFile = async (fileName: string, token: string) => {
+  try {
+    await writeFile(fileName, token, 'utf-8');
+    logger.info(`Wrote Feedly token to ${fileName}`);
+  } catch (error) {
+    logger.error(`Error writing to file: ${error}`);
   }
 };
 
@@ -157,11 +150,12 @@ const outputFeedlyToken = async (
   }
 
   const newStorageState = await fetchNewStorageState(storageStateJson);
+  const feedlyToken = feedlyTokenFromStorageState(newStorageState);
 
   await writeFile(storageStateJson, JSON.stringify(newStorageState, null, 2));
+  logger.info(`Updated storage state in ${storageStateJson}`);
 
-  await outputFeedlyToken(
-    options.output,
-    feedlyTokenFromStorageState(newStorageState),
-  );
+  if (options.output) {
+    await writeFeedlyTokenToFile(options.output, feedlyToken);
+  }
 })();

--- a/main.ts
+++ b/main.ts
@@ -136,7 +136,8 @@ const writeFeedlyTokenToFile = async (fileName: string, token: string) => {
     await writeFile(fileName, token, 'utf-8');
     logger.info(`Wrote Feedly token to ${fileName}`);
   } catch (error) {
-    logger.error(`Error writing to file: ${error}`);
+    logger.error(error, `Error writing to file: ${fileName}`);
+    throw error;
   }
 };
 


### PR DESCRIPTION
Stop printing the token to stdout by default to avoid leaking secrets
into logs and terminal history. Validate the session before writing
state.json, log the update after writeFile, and write feedlyToken to a
file only when --output is set. Update README to match.

Co-authored-by: Cursor <cursoragent@cursor.com>
