### PR TITLE
ci(lint): run eslint and tsc directly without reviewdog

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
@@ -36,19 +35,11 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Install reviewdog
-        uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
+      - name: Run eslint
+        run: npx eslint .
 
-      - name: Run eslint with reviewdog
-        uses: reviewdog/action-eslint@9b5b0150e399e1f007ee3c27bc156549810a64e3 # v1.33.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-
-      - name: Run tsc with reviewdog
-        run: npx tsc --pretty false --noEmit | reviewdog -f=tsc -reporter=github-pr-review -fail-level=error
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.github_token }}
+      - name: Run tsc
+        run: npx tsc --noEmit
 
       - name: Check Playwright version consistency
         run: |

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     // Disallow features that require cross-file awareness
     "isolatedModules": true,
 
-    "skipLibCheck": true
+    "skipLibCheck": true,
+
+    "noEmit": true
   },
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,5 @@
     "skipLibCheck": true,
 
     "noEmit": true
-  },
-  "exclude": ["node_modules"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
     "esModuleInterop": true,
 
     // Disallow features that require cross-file awareness
-    "isolatedModules": true
-  }
+    "isolatedModules": true,
+
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Replace reviewdog with plain npx eslint and tsc so lint failures fail the job reliably, and adjust tsconfig with skipLibCheck and exclude node_modules so tsc checks project sources without errors from dependencies.

Co-authored-by: Cursor <cursoragent@cursor.com>
