### PR TITLE
ci(lint): add prettier check and npm run lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     reviewers:
       - dmingn
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     reviewers:
       - dmingn

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -3,8 +3,8 @@ name: Build and push image
 on:
   pull_request:
   push:
-    branches: ["main"]
-    tags: ["*"]
+    branches: ['main']
+    tags: ['*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,11 +35,8 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Run eslint
-        run: npx eslint .
-
-      - name: Run tsc
-        run: npx tsc --noEmit
+      - name: Run lint
+        run: npm run lint
 
       - name: Check Playwright version consistency
         run: |

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ npm run dev
 
 ### Options
 
-| Option | Description |
-|--------|-------------|
-| `-o, --output <file>` | Write token to this file (default: stdout) |
-| `-v, --verbose` | Enable debug logging |
-| `-s, --screenshot-dir <dir>` | Save screenshots on success and on error |
+| Option                       | Description                                |
+| ---------------------------- | ------------------------------------------ |
+| `-o, --output <file>`        | Write token to this file (default: stdout) |
+| `-v, --verbose`              | Enable debug logging                       |
+| `-s, --screenshot-dir <dir>` | Save screenshots on success and on error   |
 
 ```bash
 make clean   # Remove screenshots/*.png

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,12 +1,11 @@
-import globals from "globals";
-import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
-
+import pluginJs from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {languageOptions: { globals: globals.browser }},
+  { files: ['**/*.{js,mjs,cjs,ts}'] },
+  { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,8 +4,10 @@ import tseslint from 'typescript-eslint';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  { files: ['**/*.{js,mjs,cjs,ts}'] },
-  { languageOptions: { globals: globals.browser } },
+  {
+    files: ['**/*.{js,mjs,cjs,ts}'],
+    languageOptions: { globals: globals.node },
+  },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
 ];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "main": "main.ts",
   "scripts": {
     "codegen": "playwright codegen feedly.com",
-    "dev": "tsx main.ts state.json --verbose --screenshot-dir screenshots"
+    "dev": "tsx main.ts state.json --verbose --screenshot-dir screenshots",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint:eslint": "eslint .",
+    "lint:typecheck": "tsc --noEmit",
+    "lint": "npm run format:check && npm run lint:eslint && npm run lint:typecheck"
   },
   "author": {
     "name": "dmingn",


### PR DESCRIPTION
Add format:check to the lint script and run npm run lint in CI so local and CI share the same checks, and apply prettier to workflow and config files that were not yet formatted.

Co-authored-by: Cursor <cursoragent@cursor.com>
