### PR TITLE
chore: remove deprecated reviewers from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'weekly'
-    reviewers:
-      - dmingn
-  - package-ecosystem: 'npm'
-    directory: '/'
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'weekly'
-    reviewers:
-      - dmingn
+      interval: "weekly"


### PR DESCRIPTION
Dependabot is retiring the reviewers option in favor of CODEOWNERS. The repo already has .github/CODEOWNERS with @dmingn, so drop the duplicated reviewers entries from dependabot.yml.

Co-authored-by: Cursor <cursoragent@cursor.com>
