### PR TITLE
chore: group Dependabot minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,17 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
Configure Dependabot to open a single PR for minor and patch updates per ecosystem (github-actions and npm), while leaving major updates as individual PRs to reduce review noise.

Co-authored-by: Cursor <cursoragent@cursor.com>
